### PR TITLE
feat: remove pin

### DIFF
--- a/extensions/manual-groups.py
+++ b/extensions/manual-groups.py
@@ -106,7 +106,6 @@ class ManualGroups(commands.Cog, name='ManualGroups'):
                     await command_message.add_reaction('🇪')
                     await command_message.add_reaction('🇲')
                     if command_message:
-                        await command_message.pin()
                         self.guild_command_message_id = command_message.id
 
         if active == 'stopp':
@@ -123,13 +122,11 @@ class ManualGroups(commands.Cog, name='ManualGroups'):
                     self.guild_study_course_channel_id)
                 msg = await channel.fetch_message(self.guild_command_message_id)
                 if msg:
-                    await msg.unpin()
                     await msg.delete()
                 channel = self.bot.get_channel(
                     self.guild_announcement_channel_id)
                 msg = await channel.fetch_message(self.guild_announcement_message_id)
                 if msg:
-                    await msg.unpin()
                     await msg.delete()
                 self.guild_command_message_id = 0
                 self.guild_announcement_message_id = 0


### PR DESCRIPTION
Explanation:
- Different behavior than everywhere else
- There will never be another message in the channel, the pinning just makes sure that the message is not the last message